### PR TITLE
Updated deployApp - Relaxed constraint on env conditional statement

### DIFF
--- a/vars/deployApp.groovy
+++ b/vars/deployApp.groovy
@@ -28,7 +28,7 @@ def call(Map parameters = [:]) {
     if (!app) {
         error 'you must provide an application name'
     }
-    if (env != 'qa' && env != 'prod') {
+    if (!env) {
         error 'you must provide a valid environment name'
     }
 


### PR DESCRIPTION
Here we have an update to `deployApp.groovy`. The constraint around the `env` variable has been removed, we simply make sure a value is set. The change was completed because of our desire to deploy `viahtml` to environments other than prod and qa.