### PR TITLE
Created onlyOnMain - A script to execute code, only on the main branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ What helpers are currently defined by this library?
 | [`buildApp`](vars/buildApp.groovy)         | function | Builds an application Docker image from a Dockerfile.                           |
 | [`buildMeta`](vars/buildMeta.groovy)       | variable | Provides access to build version metadata from git.                             |
 | [`deployApp`](vars/deployApp.groovy)       | function | Deploy an application to a named deployment environment.                        |
+| [`onlyOnMain`](vars/onlyOnMain.groovy)     | function | Execute pipeline steps only on the `main` branch.                               |
 | [`onlyOnMaster`](vars/onlyOnMaster.groovy) | function | Execute pipeline steps only on the `master` branch.                             |
 | [`releaseApp`](vars/releaseApp.groovy)     | function | Release a built application Docker image to the Docker Hub (or other registry). |
 | [`sayHello`](vars/sayHello.groovy)         | function | Hello, world!                                                                   |

--- a/vars/onlyOnMain.groovy
+++ b/vars/onlyOnMain.groovy
@@ -1,0 +1,15 @@
+#!groovy
+
+/**
+ * Execute enclosed code, only if on the main branch.
+ *
+ * Prints a message to notify when the enclosed code is being skipped on
+ * non-main branches.
+ */
+def call(Closure body) {
+    if (env.BRANCH_NAME != 'main') {
+        echo "skipping onlyOnMain steps for branch '${env.BRANCH_NAME}'"
+        return
+    }
+    body()
+}


### PR DESCRIPTION
This branch delivers a new pipeline script called, `onlyOnMain.groovy`. It is essentially a duplicate of `onlyOnMaster.groovy`. However, the new script executes code on the `main` branch which is the new GitHub default branch name.