### PR TITLE
Make the tag accessible via an arg for parameterisation in the image

### DIFF
--- a/vars/buildApp.groovy
+++ b/vars/buildApp.groovy
@@ -46,9 +46,9 @@ def call(Map parameters = [:]) {
     currentBuild.description = "Docker: ${tag}"
 
     if (!path) {
-        sh "git archive HEAD | docker build -t ${name}:${tag} -"
+        sh "git archive HEAD | docker build -t ${name}:${tag} --build-arg DOCKER_TAG=${tag} -"
     } else {
-        sh "docker build -t ${name}:${tag} ${path}"
+        sh "docker build -t ${name}:${tag} --build-arg DOCKER_TAG=${tag} ${path}"
     }
 
     return docker.image("${name}:${tag}")


### PR DESCRIPTION
This allows us to base one image on another we just built. This should help with the issues we've been seeing with the H websocket image.

This lines up with the new arg in the image here: https://github.com/hypothesis/h/blob/master/h/streamer/Dockerfile